### PR TITLE
fix for broken color of Skia - swapped red and blue

### DIFF
--- a/src/2d/DrawTargetSkia.cpp
+++ b/src/2d/DrawTargetSkia.cpp
@@ -32,6 +32,8 @@ namespace gfx {
 SkColor ColorToSkColor(const Color &color, Float aAlpha)
 {
   //XXX: do a better job converting to int
+
+  // expected ARGB but must be filled with ABGR since Skia backend is broken swapped with red and blue
   return SkColorSetARGB(U8CPU(color.a*aAlpha*255.0), U8CPU(color.b*255.0),
                         U8CPU(color.g*255.0), U8CPU(color.r*255.0));
 }


### PR DESCRIPTION
Color of Skia Target in Azure is swapped between red and blue.
This is patch for color fix.
