### PR TITLE
fix servo #472

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -126,15 +126,18 @@ all: libazure.dummy
 %.o: %.mm
 	$(CXX) -ObjC++ $< -o $@ -c $(CXXFLAGS)
 
-libazure.dummy: azure.rc $(RUST_SRC) libazure.a
+libazure.dummy: azure.rc $(RUST_SRC) libazure.a libskia.a
 	$(RUSTC) $(RUSTFLAGS) $< -o $@
 	touch $@
 
-azure-test: azure.rc $(RUST_SRC) libazure.a
+azure-test: azure.rc $(RUST_SRC) libazure.a libskia.a
 	$(RUSTC) $(RUSTFLAGS) $< -o $@ --test
 
 libazure.a: $(ALL_OBJS)
 	$(AR) rcs libazure.a $(ALL_OBJS)
+
+#Do nothing but we need to rebuild rust-azure if libskia had changed
+libskia.a:
 
 check: azure-test
 	./azure-test


### PR DESCRIPTION
fix #472
added some dummy for triggering rust-azure build when skia changed
