### PR TITLE
Add support for passing extra data to AzSkiaCreateSharedGLContext.

### DIFF
--- a/azure-c.cpp
+++ b/azure-c.cpp
@@ -152,8 +152,8 @@ AzReleaseColorPattern(AzColorPatternRef aColorPattern) {
 }
 
 extern "C" AzSkiaSharedGLContextRef
-AzCreateSkiaSharedGLContext(AzGLContext aGLContext, AzIntSize *aSize) {
-    SkNativeSharedGLContext *sharedGLContext = new SkNativeSharedGLContext(aGLContext);
+AzCreateSkiaSharedGLContext(AzGLContext aGLContext, void *extra, AzIntSize *aSize) {
+    SkNativeSharedGLContext *sharedGLContext = new SkNativeSharedGLContext(aGLContext, extra);
     if (sharedGLContext == NULL) {
         return NULL;
     }

--- a/azure-c.h
+++ b/azure-c.h
@@ -298,7 +298,7 @@ typedef GrGLSharedContext AzGLContext;
 AzColorPatternRef AzCreateColorPattern(AzColor *aColor);
 void AzReleaseColorPattern(AzColorPatternRef aColorPattern);
 
-AzSkiaSharedGLContextRef AzCreateSkiaSharedGLContext(GrGLSharedContext aSharedContext, AzIntSize *aSize);
+AzSkiaSharedGLContextRef AzCreateSkiaSharedGLContext(GrGLSharedContext aSharedContext, void *extra, AzIntSize *aSize);
 void AzRetainSkiaSharedGLContext(AzSkiaSharedGLContextRef aGLContext);
 void AzReleaseSkiaShareGLContext(AzSkiaSharedGLContextRef aGLContext);
 unsigned int AzSkiaSharedGLContextGetFBOID(AzSkiaSharedGLContextRef aGLContext);

--- a/azure.rc
+++ b/azure.rc
@@ -10,6 +10,7 @@ extern mod extra;
 extern mod geom;
 extern mod layers;
 extern mod opengles;
+extern mod glfw;
 
 pub use azure::*;
 

--- a/azure.rs
+++ b/azure.rs
@@ -281,7 +281,7 @@ pub fn AzCreateColorPattern(aColor: *AzColor) -> AzColorPatternRef;
 
 pub fn AzReleaseColorPattern(aColorPattern: AzColorPatternRef);
 
-pub fn AzCreateSkiaSharedGLContext(aGLContext: AzGLContext, aSize: *AzIntSize) -> AzSkiaSharedGLContextRef;
+pub fn AzCreateSkiaSharedGLContext(aGLContext: AzGLContext, extra: *c_void, aSize: *AzIntSize) -> AzSkiaSharedGLContextRef;
 
 pub fn AzRetainSkiaSharedGLContext(aGLContext: AzSkiaSharedGLContextRef);
 

--- a/azure_hl.rs
+++ b/azure_hl.rs
@@ -25,7 +25,10 @@ use azure::{AzSourceSurfaceGetDataSurface, AzSourceSurfaceGetFormat};
 use azure::{AzSourceSurfaceGetSize, AzCreateSkiaDrawTargetForFBO, AzSkiaGetCurrentGLContext};
 use azure::{AzSkiaSharedGLContextMakeCurrent, AzSkiaSharedGLContextGetTextureID, AzSkiaSharedGLContextFlush};
 
+use glfw;
+
 use std::libc::types::common::c99::uint16_t;
+use std::libc::c_void;
 use std::cast::transmute;
 use std::ptr;
 use std::ptr::{null, to_unsafe_ptr};
@@ -314,6 +317,7 @@ impl DrawTarget {
         assert!(backend == SkiaBackend);
         unsafe {
             let skia_context = AzCreateSkiaSharedGLContext(share_context,
+                                                           current_display(),
                                                            &size.as_azure_int_size());
             let azure_draw_target = AzCreateSkiaDrawTargetForFBO(skia_context,
                                                                  &size.as_azure_int_size(),
@@ -581,4 +585,14 @@ pub fn current_gl_context() -> AzGLContext {
     unsafe {
         AzSkiaGetCurrentGLContext()
     }
+}
+
+#[cfg(target_os="linux")]
+fn current_display() -> *c_void {
+    unsafe { glfw::ll::glfwGetX11Display() }
+}
+
+#[cfg(target_os="macos")]
+fn current_display() -> *c_void {
+    null()
 }

--- a/linkhack.rs
+++ b/linkhack.rs
@@ -5,7 +5,7 @@
 // Some crumminess to make sure we link correctly
 
 #[cfg(target_os = "linux")]
-#[link_args = "-L. -lazure -lstdc++ -lskia -lfontconfig"]
+#[link_args = "-L. -lazure -lstdc++ -lskia -lfontconfig -lX11"]
 #[nolink]
 extern { }
 


### PR DESCRIPTION
This is used on Linux to pass the `Display*` needed to avoid driver bugs with
shared contexts.

r? @pcwalton
