### PR TITLE
support android build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,9 @@ endif
 ifeq ($(UNAME),Linux)
     OSTYPE=linux
 endif
+ifeq ($(CFG_OSTYPE),linux-androideabi)
+    OSTYPE=android
+endif
 
 MOZALLOC_CPP_SRC = \
 	src/memory/mozalloc/mozalloc_abort.cpp \
@@ -29,7 +32,6 @@ AZURE_CPP_SRC = \
 		DrawTargetRecording.cpp \
 		Factory.cpp \
 		ImageScaling.cpp \
-		ImageScalingSSE2.cpp \
 		Matrix.cpp \
 		PathRecording.cpp \
 		RecordedEvent.cpp \
@@ -40,6 +42,9 @@ AZURE_CPP_SRC = \
 		convolver.cpp \
 		image_operations.cpp)
 
+ifneq ($(CFG_CPUTYPE), arm)
+    AZURE_CPP_SRC += $(addprefix src/gfx/2d/, ImageScalingSSE2.cpp)
+endif
 AZURE_CPP_SRC += azure-c.cpp
 
 ifeq ($(CFG_ENABLE_DEBUG),1)
@@ -61,7 +66,6 @@ endif
 #SSE2 instruction support required.
 CXXFLAGS += \
 	-fPIC \
-	-msse2 \
 	-I$(VPATH)/include \
 	-I$(VPATH)/include/mozilla/gfx \
 	-I$(VPATH)/include/mozilla/ipc/chromium/src \
@@ -72,6 +76,11 @@ CXXFLAGS += \
 	-DMOZ_GFX \
 	-DNS_ATTR_MALLOC="" -DNS_WARN_UNUSED_RESULT="" \
 	$(NULL)
+
+#SSE2 instruction support required.
+ifneq ($(CFG_CPUTYPE), arm)
+    CXXFLAGS += -msse2
+endif
 
 AZURE_CPP_SRC += \
 	$(addprefix src/gfx/2d/,\
@@ -125,6 +134,19 @@ CXXFLAGS += -DMOZ_ENABLE_FREETYPE
 AZURE_CPP_SRC += \
 	$(addprefix src/gfx/2d/,\
 		ScaledFontFreetype.cpp)
+endif
+
+ifeq ($(OSTYPE),android)
+    CXXFLAGS += \
+    -DXP_UNIX \
+    -DSK_BUILD_FOR_ANDROID \
+    $(NULL)
+    AZURE_OBJCPP_SRC =
+
+    CXXFLAGS += -DMOZ_ENABLE_FREETYPE
+    AZURE_CPP_SRC += \
+        $(addprefix src/gfx/2d/,\
+            ScaledFontFreetype.cpp)
 endif
 
 ALL_CPP_SRC = $(MOZALLOC_CPP_SRC) $(AZURE_CPP_SRC)

--- a/azure.rc
+++ b/azure.rc
@@ -11,6 +11,7 @@ extern mod extra;
 extern mod geom;
 extern mod layers;
 extern mod opengles;
+#[cfg(not(target_os = "android"))]
 extern mod glfw;
 
 pub use azure::*;

--- a/azure_hl.rs
+++ b/azure_hl.rs
@@ -595,3 +595,8 @@ fn current_display() -> *c_void {
 fn current_display() -> *c_void {
     null()
 }
+
+#[cfg(target_os="android")]
+fn current_display() -> *c_void {
+        null()
+}

--- a/linkhack.rs
+++ b/linkhack.rs
@@ -9,6 +9,11 @@
 #[nolink]
 extern { }
 
+#[cfg(target_os = "android")]
+#[link_args = "-L. -lazure -lstdc++ -lskia -lexpat -lfontconfig -lEGL"]
+#[nolink]
+extern { }
+
 #[cfg(target_os = "macos")]
 #[link_args = "-L. -lazure -lstdc++ -framework ApplicationServices \
 			   -lskia -framework IOSurface -lobjc -framework OpenGL \

--- a/scaled_font.rs
+++ b/scaled_font.rs
@@ -18,6 +18,9 @@ priv use scaled_font::macos::*;
 #[cfg(target_os="linux")]
 priv use scaled_font::linux::*;
 
+#[cfg(target_os="android")]
+priv use scaled_font::android::*;
+
 #[cfg(target_os="macos")]
 pub mod macos {
     extern mod core_graphics;
@@ -32,6 +35,13 @@ pub mod linux {
     extern mod freetype;
 
     pub use scaled_font::linux::freetype::freetype::{FT_Face, FT_LOAD_DEFAULT};
+}
+
+#[cfg(target_os="android")]
+pub mod android {
+    extern mod freetype;
+
+    pub use scaled_font::android::freetype::freetype::{FT_Face, FT_LOAD_DEFAULT};
 }
 
 type SkTypeface = *c_void;
@@ -54,6 +64,7 @@ impl ScaledFont {
     }
 
     #[cfg(target_os="linux")]
+    #[cfg(target_os="android")]
     pub fn new(backend: BackendType, native_font: FT_Face, size: AzFloat)
         -> ScaledFont {
         use azure::AZ_NATIVE_FONT_SKIA_FONT_FACE;


### PR DESCRIPTION
support android build
we use glut on android, and use glfw on linux & mac.
This commit does not affect to each submodule's original standalone build system.
