### PR TITLE
Cloneable color

### DIFF
--- a/azure_hl.rs
+++ b/azure_hl.rs
@@ -80,6 +80,7 @@ impl AsAzurePoint for Point2D<AzFloat> {
     }
 }
 
+#[deriving(Clone)]
 pub struct Color {
     r: AzFloat,
     g: AzFloat,


### PR DESCRIPTION
Color can be cloneable.
If we want to call new_all_same with Color, Color should be cloneable.
Internally, `geom::SideOffsets2D::new_all_same(all:T)` uses `all.clone()`
