### PR TITLE
Support StrokeStyle

### DIFF
--- a/azure-c.h
+++ b/azure-c.h
@@ -250,7 +250,7 @@ typedef struct _AzStrokeOptions {
   const AzFloat* mDashPattern;
   size_t mDashLength;
   AzFloat mDashOffset;
-  uint16_t fields;
+  uint8_t fields;
   /*
     enum AzJoinStyle mLineJoin : 4;
     enum AzCapStyle mLineCap : 3;

--- a/azure.rs
+++ b/azure.rs
@@ -218,7 +218,7 @@ pub struct struct__AzStrokeOptions {
     mDashPattern: *AzFloat,
     mDashLength: size_t,
     mDashOffset: AzFloat,
-    fields: uint16_t,
+    fields: uint8_t,
 }
 
 pub type AzStrokeOptions = struct__AzStrokeOptions;

--- a/azure_hl.rs
+++ b/azure_hl.rs
@@ -4,6 +4,7 @@
 
 //! High-level bindings to Azure.
 
+use azure::{AZ_CAP_BUTT, AZ_JOIN_MITER_OR_BEVEL};
 use azure::{AzPoint, AzRect, AzFloat, AzIntSize, AzColor, AzColorPatternRef};
 use azure::{AzStrokeOptions, AzDrawOptions, AzSurfaceFormat, AzFilter, AzDrawSurfaceOptions};
 use azure::{AzBackendType, AzDrawTargetRef, AzSourceSurfaceRef, AzDataSourceSurfaceRef};
@@ -25,8 +26,8 @@ use azure::{AzSourceSurfaceGetDataSurface, AzSourceSurfaceGetFormat};
 use azure::{AzSourceSurfaceGetSize, AzCreateSkiaDrawTargetForFBO, AzSkiaGetCurrentGLContext};
 use azure::{AzSkiaSharedGLContextMakeCurrent, AzSkiaSharedGLContextGetTextureID, AzSkiaSharedGLContextFlush};
 
-use std::libc::types::common::c99::uint16_t;
-use std::libc::c_void;
+use std::libc::types::common::c99::{uint8_t, uint16_t};
+use std::libc::{c_void, size_t};
 use std::cast::transmute;
 use std::ptr;
 use std::ptr::{null, to_unsafe_ptr};
@@ -123,7 +124,9 @@ pub fn ColorPattern(color: Color) -> ColorPattern {
 pub struct StrokeOptions {
     line_width: AzFloat,
     miter_limit: AzFloat,
-    fields: uint16_t,
+    mDashPattern: *AzFloat,
+    mDashLength: size_t,
+    fields: uint8_t
 }
 
 impl StrokeOptions {
@@ -131,21 +134,32 @@ impl StrokeOptions {
         struct__AzStrokeOptions {
             mLineWidth: self.line_width,
             mMiterLimit: self.miter_limit,
-            mDashPattern: null(),
-            mDashLength: 0,
+            mDashPattern: self.mDashPattern,
+            mDashLength: self.mDashLength,
             mDashOffset: 0.0f as AzFloat,
             fields: self.fields
         }
     }
+
+    pub fn set_join_style(&mut self, style: u8) {
+        self.fields = self.fields & 0b1111_0000_u8;
+        self.fields = self.fields | style ;
+    }
+
+    pub fn set_cap_style(&mut self, style: u8) {
+        self.fields = self.fields & 0b0000_1111_u8;
+        self.fields = self.fields | (style << 4);
+    }
 }
 
 pub fn StrokeOptions(line_width: AzFloat,
-                  miter_limit: AzFloat,
-                  fields: uint16_t) -> StrokeOptions {
+                  miter_limit: AzFloat) -> StrokeOptions {
     StrokeOptions {
         line_width: line_width,
         miter_limit: miter_limit,
-        fields: fields
+        mDashPattern: null(),
+        mDashLength: 0,
+        fields: AZ_CAP_BUTT as u8 << 4 | AZ_JOIN_MITER_OR_BEVEL as u8
     }
 }
 


### PR DESCRIPTION
I modified some codes in azure to support StrokeStyle like cap-style, join-style and some others. But there are some problems.
First of them, It doesn't look the join-style works well. I tested it join-style bits beside cap-style in C. It looks 21(cap,join) as hex in C. So as you can see in code, I implemented set method in azure_hl. I think the bit is set properly but the only join_style isn't applied that I want.(I tested CAP_BUTT and CAP_ROUND. Both of them work fine. )
Second, I will send PR  about border-style after this is merged. I can render DashedBorderStyle but can't render DottedBorderStyle as I expect. Because I supposed servo and firefox uses same graphic engine. So  I refered to firefox code(link : http://mxr.mozilla.org/mozilla-central/source/layout/base/nsCSSRenderingBorders.cpp#1080) to render them properly specially for DashPattern and cap, join style.
If you can catch what thoes problem are, let me know that I will fix it before it's merged. But I think second one is you might catch after I send main codes for border-style.
