### PR TITLE
Fix memory leak from bad refcounting

### DIFF
--- a/azure-c.cpp
+++ b/azure-c.cpp
@@ -236,7 +236,6 @@ extern "C" AzDrawTargetRef
 AzCreateSkiaDrawTargetForFBO(AzSkiaSharedGLContextRef aGLContext, AzIntSize *aSize, AzSurfaceFormat aFormat) {
     SkNativeSharedGLContext *sharedGLContext = static_cast<SkNativeSharedGLContext*>(aGLContext);
     GrContext *grContext = sharedGLContext->getGrContext();
-    grContext->AddRef();
     gfx::IntSize *size = reinterpret_cast<gfx::IntSize*>(aSize);
     gfx::SurfaceFormat surfaceFormat = static_cast<gfx::SurfaceFormat>(aFormat);
     RefPtr<gfx::DrawTarget> target = gfx::Factory::CreateSkiaDrawTargetForFBO(sharedGLContext->getFBOID(),


### PR DESCRIPTION
CreateSkiaDrawTargetForFBO will increment the refcount on grContext, so we
don't need to do it as well.
