### PR TITLE
Allow more Porter-Duff compositing modes for rect fills.

### DIFF
--- a/azure-c.cpp
+++ b/azure-c.cpp
@@ -306,12 +306,17 @@ AzDrawTargetPopClip(AzDrawTargetRef aDrawTarget) {
 }
 
 extern "C" void
-AzDrawTargetFillRect(AzDrawTargetRef aDrawTarget, AzRect *aRect,
-		     AzPatternRef aPattern) {
+AzDrawTargetFillRect(AzDrawTargetRef aDrawTarget,
+                     AzRect* aRect,
+		             AzPatternRef aPattern,
+                     AzDrawOptions* aDrawOptions) {
     gfx::DrawTarget *gfxDrawTarget = static_cast<gfx::DrawTarget*>(aDrawTarget);
     gfx::Rect *gfxRect = reinterpret_cast<gfx::Rect*>(aRect);
     gfx::Pattern *gfxPattern = static_cast<gfx::Pattern*>(aPattern);
-    gfxDrawTarget->FillRect(*gfxRect, *gfxPattern);
+    gfx::DrawOptions *gfxDrawOptions = reinterpret_cast<gfx::DrawOptions*>(aDrawOptions);
+    gfxDrawTarget->FillRect(*gfxRect,
+                            *gfxPattern,
+                            gfxDrawOptions != NULL ? *gfxDrawOptions : gfx::DrawOptions());
 }
 
 extern "C" void

--- a/azure-c.h
+++ b/azure-c.h
@@ -334,8 +334,9 @@ AzIntSize AzDrawTargetGetSize(AzDrawTargetRef aDrawTarget);
 void AzDrawTargetFlush(AzDrawTargetRef aDrawTarget);
 void AzDrawTargetClearRect(AzDrawTargetRef aDrawTarget, AzRect *aRect);
 void AzDrawTargetFillRect(AzDrawTargetRef aDrawTarget,
-			  AzRect *aRect,
-			  AzPatternRef aPattern);
+			              AzRect* aRect,
+			              AzPatternRef aPattern,
+                          AzDrawOptions* aDrawOptions);
 void AzDrawTargetStrokeRect(AzDrawTargetRef aDrawTarget,
 			    AzRect *aRect,
 			    AzPatternRef aPattern,

--- a/azure.rs
+++ b/azure.rs
@@ -345,7 +345,10 @@ pub fn AzDrawTargetFlush(aDrawTarget: AzDrawTargetRef);
 
 pub fn AzDrawTargetClearRect(aDrawTarget: AzDrawTargetRef, aRect: *AzRect);
 
-pub fn AzDrawTargetFillRect(aDrawTarget: AzDrawTargetRef, aRect: *AzRect, aPattern: AzPatternRef);
+pub fn AzDrawTargetFillRect(aDrawTarget: AzDrawTargetRef,
+                            aRect: *AzRect,
+                            aPattern: AzPatternRef,
+                            aDrawOptions: *AzDrawOptions);
 
 pub fn AzDrawTargetStrokeRect(aDrawTarget: AzDrawTargetRef, aRect: *AzRect, aPattern: AzPatternRef, aStrokeOptions: *AzStrokeOptions, aDrawOptions: *AzDrawOptions);
 

--- a/azure_hl.rs
+++ b/azure_hl.rs
@@ -127,6 +127,35 @@ pub fn ColorPattern(color: Color) -> ColorPattern {
     }
 }
 
+pub enum CompositionOp {
+    OverOp,
+    AddOp,
+    AtopOp,
+    OutOp,
+    InOp,
+    SourceOp,
+    DestInOp,
+    DestOutOp,
+    DestOverOp,
+    DestAtopOp,
+    XorOp,
+    MultiplyOp,
+    ScreenOp,
+    OverlayOp,
+    DarkenOp,
+    LightenOp,
+    ColorDodgeOp,
+    ColorBurnOp,
+    HardLightOp,
+    SoftLightOp,
+    DifferenceOp,
+    ExclusionOp,
+    HueOp,
+    SaturationOp,
+    ColorOp,
+    LuminosityOp,
+}
+
 pub struct StrokeOptions {
     line_width: AzFloat,
     miter_limit: AzFloat,
@@ -182,9 +211,9 @@ impl DrawOptions {
         }
     }
 
-    pub fn set_composition_op(&mut self, style: u8) {
+    pub fn set_composition_op(&mut self, style: CompositionOp) {
         self.fields = self.fields & 0b1111_1111_0000_0000_u16;
-        self.fields = self.fields | style as u16;
+        self.fields = self.fields | (style as u16);
     }
 
     pub fn set_antialias_mode(&mut self, style: u8) {
@@ -449,11 +478,25 @@ impl DrawTarget {
         }
     }
 
-    pub fn fill_rect(&self, rect: &Rect<AzFloat>, pattern: &ColorPattern) {
+    pub fn fill_rect(&self,
+                     rect: &Rect<AzFloat>,
+                     pattern: &ColorPattern,
+                     draw_options: Option<&DrawOptions>) {
         unsafe {
+            let draw_options = draw_options.map(|draw_options| {
+                draw_options.as_azure_draw_options()
+            });
+            let draw_options = match draw_options {
+                None => ptr::null(),
+                Some(draw_options) => {
+                    let draw_options: *AzDrawOptions = &draw_options;
+                    draw_options
+                }
+            };
             AzDrawTargetFillRect(self.azure_draw_target,
                                  &rect.as_azure_rect(),
-                                 pattern.azure_color_pattern);
+                                 pattern.azure_color_pattern,
+                                 draw_options);
         }
     }
 


### PR DESCRIPTION
r? @metajack 

@pcwalton made these changes, but we need them merged into rust-azure master so we can do the rust upgrade
