### PR TITLE
Add support for creating faces (for linux/android) from a memory buffer.

### DIFF
--- a/azure-c.cpp
+++ b/azure-c.cpp
@@ -459,11 +459,26 @@ AzDrawTargetSetTransform(AzDrawTargetRef aDrawTarget,
 }
 
 extern "C" AzFontOptions*
-AzCreateFontOptions(char *aName, AzFontStyle aStyle) {
+AzCreateFontOptionsForName(char *aName, AzFontStyle aStyle) {
     #ifdef MOZ_ENABLE_FREETYPE
     gfx::FontOptions *options = new gfx::FontOptions;
     options->mName = std::string(aName);
     options->mStyle = static_cast<gfx::FontStyle>(aStyle);
+    options->mData = NULL;
+    options->mDataSize = 0;
+    return options;
+    #else
+    abort();
+    #endif
+}
+
+extern "C" AzFontOptions*
+AzCreateFontOptionsForData(uint8_t *aFontData, uint32_t aFontDataSize) {
+    #ifdef MOZ_ENABLE_FREETYPE
+    gfx::FontOptions *options = new gfx::FontOptions;
+    options->mStyle = gfx::FONT_STYLE_NORMAL;
+    options->mData = aFontData;
+    options->mDataSize = aFontDataSize;
     return options;
     #else
     abort();

--- a/azure-c.h
+++ b/azure-c.h
@@ -380,7 +380,8 @@ void AzReleaseScaledFont(AzScaledFontRef aFont);
 
 /* Helpers */
 typedef void AzFontOptions;
-AzFontOptions* AzCreateFontOptions(char *aName, AzFontStyle aStyle);
+AzFontOptions* AzCreateFontOptionsForName(char *aName, AzFontStyle aStyle);
+AzFontOptions* AzCreateFontOptionsForData(uint8_t *aFontData, uint32_t aFontDataSize);
 void AzDestroyFontOptions(AzFontOptions* aOptions);
 
 AzGLContext AzSkiaGetCurrentGLContext();

--- a/azure.rc
+++ b/azure.rc
@@ -73,7 +73,7 @@ pub use azure::{AzFontOptions, AzFloat, enum_AzSurfaceType, AZ_SURFACE_DATA,
                 AzDrawTargetDrawSurface, AzDrawTargetGetSnapshot, AzDrawTargetCreateSourceSurfaceFromData, AzReleaseSourceSurface, 
                 AzSourceSurfaceGetSize, AzSourceSurfaceGetFormat, AzSourceSurfaceGetDataSurface, AzDataSourceSurfaceGetData, 
                 AzDataSourceSurfaceGetStride, AzCreateScaledFontForNativeFont, AzReleaseScaledFont, AzDrawTargetSetTransform, 
-                AzCreateFontOptions, AzDestroyFontOptions, AzSkiaGetCurrentGLContext, AzCreatePathBuilder, 
+                AzCreateFontOptionsForData, AzCreateFontOptionsForName, AzDestroyFontOptions, AzSkiaGetCurrentGLContext, AzCreatePathBuilder, 
                 AzReleasePathBuilder, AzPathBuilderMoveTo, AzPathBuilderLineTo, AzPathBuilderFinish, AzReleasePath};
 
 pub mod azure_hl;

--- a/azure.rs
+++ b/azure.rs
@@ -386,7 +386,9 @@ pub fn AzReleaseScaledFont(aFont: AzScaledFontRef);
 
 pub fn AzDrawTargetSetTransform(aDrawTarget: AzDrawTargetRef, aTransform: *AzMatrix);
 
-pub fn AzCreateFontOptions(aName: *c_char, aStyle: enum_AzFontStyle) -> *AzFontOptions;
+pub fn AzCreateFontOptionsForData(aFontData: *u8, aFontDataSize: u32) -> *AzFontOptions;
+
+pub fn AzCreateFontOptionsForName(aName: *c_char, aStyle: enum_AzFontStyle) -> *AzFontOptions;
 
 pub fn AzDestroyFontOptions(aOptions: *AzFontOptions);
 

--- a/include/mozilla/gfx/2D.h
+++ b/include/mozilla/gfx/2D.h
@@ -517,6 +517,8 @@ struct FontOptions
 {
   std::string mName;
   FontStyle mStyle;
+  uint8_t *mData;
+  uint32_t mDataSize;
 };
 #endif
 

--- a/src/gfx/2d/ScaledFontFreetype.cpp
+++ b/src/gfx/2d/ScaledFontFreetype.cpp
@@ -8,6 +8,7 @@
 
 #ifdef USE_SKIA
 #include "SkTypeface.h"
+#include "SkStream.h"
 #endif
 
 #include <string>
@@ -37,13 +38,19 @@ fontStyleToSkia(FontStyle aStyle)
 }
 #endif
 
-// Ideally we want to use FT_Face here but as there is currently no way to get
-// an SkTypeface from an FT_Face we do this.
 ScaledFontFreetype::ScaledFontFreetype(FontOptions* aFont, Float aSize)
   : ScaledFontBase(aSize)
 {
 #ifdef USE_SKIA
-  mTypeface = SkTypeface::CreateFromName(aFont->mName.c_str(), fontStyleToSkia(aFont->mStyle));
+  if (aFont->mData)
+  {
+    SkStream *stream = new SkMemoryStream(aFont->mData, aFont->mDataSize, true);
+    mTypeface = SkTypeface::CreateFromStream(stream);
+  }
+  else
+  {
+    mTypeface = SkTypeface::CreateFromName(aFont->mName.c_str(), fontStyleToSkia(aFont->mStyle));
+  }
 #endif
 }
 


### PR DESCRIPTION
This allows us to avoid the fragility of hoping that azure/skia create the correct font by passing a string identifier that matches what servo is using.
