### PR TITLE
Added non_snake_case_functions to list of allowed policies

### DIFF
--- a/azure.rc
+++ b/azure.rc
@@ -8,6 +8,7 @@
 #![crate_type = "rlib"]
 
 #![feature(globs)]
+#![allow(non_snake_case_functions)]
 
 extern crate libc;
 extern crate std;


### PR DESCRIPTION
This avoid some compilation warnings while compiling Servo.
