### PR TITLE
Fix dangling pointer causing corrupted output in fill_rect

### DIFF
--- a/azure_hl.rs
+++ b/azure_hl.rs
@@ -482,15 +482,12 @@ impl DrawTarget {
                      pattern: &ColorPattern,
                      draw_options: Option<&DrawOptions>) {
         unsafe {
-            let draw_options = draw_options.map(|draw_options| {
+            let mut draw_options = draw_options.map(|draw_options| {
                 draw_options.as_azure_draw_options()
             });
             let draw_options = match draw_options {
                 None => ptr::mut_null(),
-                Some(mut draw_options) => {
-                    let draw_options: *mut AzDrawOptions = &mut draw_options;
-                    draw_options
-                }
+                Some(ref mut draw_options) => draw_options as *mut AzDrawOptions
             };
             AzDrawTargetFillRect(self.azure_draw_target,
                                  &mut rect.as_azure_rect(),


### PR DESCRIPTION
The `draw_options` variable within the match expression is only valid
for the duration of the match expression, but by using an unsafe pointer
the code manages to violate the lifetime rules and creates a pointer
to it that's outlives the match expression.

Instead of creating a copy of the AzDrawOptions in the match, we can get
a ref to the one contained in the Option and hand out of pointer to that
one, which lives long enough.

Refs servo/servo#3084.
