### PR TITLE
libazure: Enable subpixel text in Skia.

### DIFF
--- a/libazure/src/gfx/2d/DrawTargetSkia.cpp
+++ b/libazure/src/gfx/2d/DrawTargetSkia.cpp
@@ -461,6 +461,7 @@ DrawTargetSkia::FillGlyphs(ScaledFont *aFont,
   paint.mPaint.setTypeface(skiaFont->GetSkTypeface());
   paint.mPaint.setTextSize(SkFloatToScalar(skiaFont->mSize));
   paint.mPaint.setTextEncoding(SkPaint::kGlyphID_TextEncoding);
+  paint.mPaint.setSubpixelText(true);
   
   std::vector<uint16_t> indices;
   std::vector<SkPoint> offsets;


### PR DESCRIPTION
Drastically improves text rendering in Servo, especially on non-Retina
displays.

r? @metajack
