### PR TITLE
Link to libGL on Linux in the test module. This allows the unit tests for azure to link correctly.

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -2,6 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// The azure unit tests require this
+// on Linux to link correctly.
+
+#[cfg(target_os = "linux")]
+#[link(name = "GL")]
+extern { }
+
 #[test]
 fn sanity_check() {
     use azure::AzSanityCheck;


### PR DESCRIPTION
This code previously existed in rust-opengles, but azure no longer depends on rust-opengles.
