### PR TITLE
Implement a `FillWithBlur` method for `box-shadow`

### DIFF
--- a/libazure/include/mozilla/gfx/2D.h
+++ b/libazure/include/mozilla/gfx/2D.h
@@ -709,6 +709,24 @@ public:
                     const DrawOptions &aOptions = DrawOptions()) = 0;
 
   /*
+   * Draws a shadow around the given path. The transform *is* taken into
+   * account, unlike |DrawSurfaceWithShadow()|.
+   *
+   * aPath Path that is to be shadowed
+   * aColor The color of the shadow
+   * aOffset The offset of the shadow from the path
+   * aSigma The sigma for the blur
+   * aOperator The composition operator for the operation
+   */
+  virtual void DrawShadow(const Path &aPath,
+                          const Color &aColor,
+                          const Point &aOffset,
+                          Float aSigma,
+                          CompositionOp aOperator) {
+    // Default: no-op.
+  }
+
+  /*
    * Push a clip to the DrawTarget.
    *
    * aPath The path to clip to

--- a/libazure/src/gfx/2d/DrawTargetSkia.h
+++ b/libazure/src/gfx/2d/DrawTargetSkia.h
@@ -75,6 +75,11 @@ public:
   virtual void Mask(const Pattern &aSource,
                     const Pattern &aMask,
                     const DrawOptions &aOptions = DrawOptions());
+  virtual void DrawShadow(const Path &aPath,
+                          const Color &aColor,
+                          const Point &aOffset,
+                          Float aSigma,
+                          CompositionOp aOperator);
   virtual void PushClip(const Path *aPath);
   virtual void PushClipRect(const Rect& aRect);
   virtual void PopClip();

--- a/src/azure-c.cpp
+++ b/src/azure-c.cpp
@@ -321,6 +321,25 @@ AzDrawTargetFillRect(AzDrawTargetRef aDrawTarget,
 }
 
 extern "C" void
+AzDrawTargetDrawShadow(AzDrawTargetRef aDrawTarget,
+                       AzPathRef aPath,
+                       const AzColor *aColor,
+                       const AzPoint *aOffset,
+                       AzFloat aSigma,
+                       AzCompositionOp aOperator) {
+    gfx::DrawTarget *gfxDrawTarget = static_cast<gfx::DrawTarget*>(aDrawTarget);
+    gfx::Path *gfxPath = reinterpret_cast<gfx::Path*>(aPath);
+    const gfx::Color *gfxColor = reinterpret_cast<const gfx::Color*>(aColor);
+    const gfx::Point *gfxOffset = reinterpret_cast<const gfx::Point*>(aOffset);
+    gfx::CompositionOp gfxOperator = static_cast<gfx::CompositionOp>(aOperator);
+    gfxDrawTarget->DrawShadow(*gfxPath,
+                              *gfxColor,
+                              *gfxOffset,
+                              aSigma,
+                              gfxOperator);
+}
+
+extern "C" void
 AzDrawTargetStrokeRect(AzDrawTargetRef aDrawTarget, AzRect *aRect,
 		       AzPatternRef aPattern, AzStrokeOptions *aStrokeOptions,
 		       AzDrawOptions *aDrawOptions) {

--- a/src/azure-c.h
+++ b/src/azure-c.h
@@ -333,9 +333,15 @@ AzIntSize AzDrawTargetGetSize(AzDrawTargetRef aDrawTarget);
 void AzDrawTargetFlush(AzDrawTargetRef aDrawTarget);
 void AzDrawTargetClearRect(AzDrawTargetRef aDrawTarget, AzRect *aRect);
 void AzDrawTargetFillRect(AzDrawTargetRef aDrawTarget,
-			              AzRect* aRect,
-			              AzPatternRef aPattern,
+			                    AzRect* aRect,
+			                    AzPatternRef aPattern,
                           AzDrawOptions* aDrawOptions);
+void AzDrawTargetDrawShadow(AzDrawTargetRef aDrawTarget,
+                            AzPathRef aPath,
+                            const AzColor *aColor,
+                            const AzPoint *aOffset,
+                            AzFloat aSigma,
+                            AzCompositionOp aOperator);
 void AzDrawTargetStrokeRect(AzDrawTargetRef aDrawTarget,
 			    AzRect *aRect,
 			    AzPatternRef aPattern,

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -376,6 +376,13 @@ pub fn AzDrawTargetFillRect(aDrawTarget: AzDrawTargetRef,
                             aPattern: AzPatternRef,
                             aDrawOptions: *mut AzDrawOptions);
 
+pub fn AzDrawTargetDrawShadow(aDrawTarget: AzDrawTargetRef,
+                              aPath: AzPathRef,
+                              aColor: *const AzColor,
+                              aPoint: *const AzPoint,
+                              aSigma: AzFloat,
+                              aOperator: AzCompositionOp);
+
 pub fn AzDrawTargetStrokeRect(aDrawTarget: AzDrawTargetRef, aRect: *mut AzRect, aPattern: AzPatternRef, aStrokeOptions: *mut AzStrokeOptions, aDrawOptions: *mut AzDrawOptions);
 
 pub fn AzDrawTargetStrokeLine(aDrawTarget: AzDrawTargetRef, aStart: *mut AzPoint, aEnd: *mut AzPoint, aPattern: AzPatternRef, aStrokeOptions: *mut AzStrokeOptions, aDrawOptions: *mut AzDrawOptions);

--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -22,7 +22,7 @@ use azure::{AzReleaseSkiaSharedGLContext, AzRetainSkiaSharedGLContext};
 use azure::{AzDrawTargetDrawSurface, AzDrawTargetFillRect, AzDrawTargetFlush};
 use azure::{AzDrawTargetGetSize, AzDrawTargetGetSnapshot, AzDrawTargetSetTransform};
 use azure::{AzDrawTargetStrokeLine, AzDrawTargetStrokeRect, AzDrawTargetFillGlyphs};
-use azure::{AzDrawTargetCreateGradientStops};
+use azure::{AzDrawTargetCreateGradientStops, AzDrawTargetDrawShadow};
 use azure::{AzReleaseDrawTarget, AzReleasePattern, AzReleaseGradientStops};
 use azure::{AzReleaseSourceSurface, AzRetainDrawTarget};
 use azure::{AzSourceSurfaceGetDataSurface, AzSourceSurfaceGetFormat};
@@ -92,7 +92,7 @@ impl AsAzurePoint for Point2D<AzFloat> {
     }
 }
 
-#[deriving(Clone)]
+#[deriving(Clone, Show)]
 pub struct Color {
     pub r: AzFloat,
     pub g: AzFloat,
@@ -111,7 +111,6 @@ impl Color {
 }
 
 
-// FIXME: Should have a class hierarchy here starting with Pattern.
 pub struct ColorPattern {
     pub azure_color_pattern: AzColorPatternRef,
 }
@@ -500,6 +499,22 @@ impl DrawTarget {
                                  &mut rect.as_azure_rect(),
                                  pattern.as_azure_pattern(),
                                  draw_options);
+        }
+    }
+
+    pub fn draw_shadow(&self,
+                       path: &Path,
+                       color: &Color,
+                       point: &Point2D<AzFloat>,
+                       sigma: AzFloat,
+                       operator: CompositionOp) {
+        unsafe {
+            AzDrawTargetDrawShadow(self.azure_draw_target,
+                                   path.azure_path,
+                                   &color.as_azure_color(),
+                                   &point.as_azure_point(),
+                                   sigma,
+                                   operator as AzCompositionOp)
         }
     }
 


### PR DESCRIPTION
This seems to allow us to achieve the correct behavior cleanly. I've only implemented this in the Skia backend for now, where it ought to be GPU accelerated if Skia supports that (via `SkShader`).

r? @SimonSapin
