### PR TITLE
Fix compile on android build, which uses strongly typed enums.

### DIFF
--- a/src/azure-c.cpp
+++ b/src/azure-c.cpp
@@ -291,7 +291,7 @@ AzDrawTargetGetSize(AzDrawTargetRef aDrawTarget) {
 extern "C" AzSurfaceFormat
 AzDrawTargetGetFormat(AzDrawTargetRef aDrawTarget) {
     gfx::DrawTarget *gfxDrawTarget = static_cast<gfx::DrawTarget*>(aDrawTarget);
-    return static_cast<AzSurfaceFormat>(gfxDrawTarget->GetFormat());
+    return static_cast<AzSurfaceFormat>(static_cast<int>(gfxDrawTarget->GetFormat()));
 }
 
 extern "C" void


### PR DESCRIPTION
With strongly typed enums that are of different size, neither
static_cast nor reinterpret_cast by themselves are enough, so
static_cast to an int and then to the desired type.
