### PR TITLE
Fix gonk build

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -36,7 +36,7 @@ AZURE_CPP_SRC = \
 	libazure/SourceSurfaceSkia.cpp
 
 CXXFLAGS += \
-	-std=c++11 \
+	-std=gnu++11 \
 	-fPIC \
 	-Ilibazure \
 	-DMOZ_GFX \


### PR DESCRIPTION
Gonk uses stlport, which disables long long support when --std=c++11 is used.
long long support is necessary for Logging.h.
