### PR TITLE
Remove the dependency on rust-layers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,6 @@ build = "make -f makefile.cargo"
 
 git = "https://github.com/servo/rust-geom"
 
-[dependencies.layers]
-
-git = "https://github.com/servo/rust-layers"
-
 [dependencies.skia-sys]
 
 git = "https://github.com/servo/skia"

--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -60,7 +60,6 @@ use geom::matrix2d::Matrix2D;
 use geom::point::Point2D;
 use geom::rect::Rect;
 use geom::size::Size2D;
-use layers::platform::surface::NativePaintingGraphicsContext;
 use libc::types::common::c99::{uint8_t, uint16_t};
 use libc::size_t;
 use std::mem;
@@ -424,11 +423,10 @@ impl DrawTarget {
     }
 
     pub fn new_with_fbo(backend: BackendType,
-                        native_graphics_context: &NativePaintingGraphicsContext,
+                        native_graphics_context: AzGLNativeContextRef,
                         size: Size2D<i32>,
                         format: SurfaceFormat) -> DrawTarget {
         assert!(backend == BackendType::Skia);
-        let native_graphics_context = native_graphics_context as *const _ as AzGLNativeContextRef;
         let skia_context = unsafe {
             AzCreateSkiaSharedGLContext(native_graphics_context,
                                         &mut size.as_azure_int_size())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 extern crate libc;
 extern crate geom;
-extern crate layers;
 #[cfg(target_os = "linux")]
 extern crate xlib;
 #[cfg(target_os = "android")]


### PR DESCRIPTION
This is to allow rust-layers to depend on azure and avoid a circular
dependency. rust-layers will soon be handling more of the glue that
attaches shared surfaces to Servo.