### PR TITLE
Enhance the detection of SSE2-compatible targets

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -77,7 +77,13 @@ CXXFLAGS += \
 
 USE_CLANG = $(shell $(CXX) --version|grep -c 'clang')
 
-ifneq (arm,$(findstring arm,$(TARGET)))
+ifeq (i686,$(findstring i686,$(TARGET)))
+	supports_sse = true
+endif
+ifeq (x86_64,$(findstring x86_64,$(TARGET)))
+	supports_sse = true
+endif
+ifeq (true,$(supports_sse))
 AZURE_CPP_SRC += \
 	libazure/BlurSSE2.cpp \
 	libazure/FilterProcessingSSE2.cpp \


### PR DESCRIPTION
Assuming that any target that doesn't have "arm" in its name is i686 or x86_64
and thus SSE2-compatible is incorrect (counter example: aarch64). It's better to
look for "86", which appears in the name of all 8086 descendants.