### PR TITLE
Fix build after PR #137

### DIFF
--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -400,7 +400,7 @@ impl DrawTarget {
 
     pub fn new_with_data(backend: BackendType,
                          mut data: Vec<u8>,
-                         offset: isize,
+                         offset: usize,
                          size: Size2D<i32>,
                          stride: i32,
                          format: SurfaceFormat) -> DrawTarget {


### PR DESCRIPTION
After that PR the build fails with:

mismatched types: expected `usize`, found `isize` (expected usize, found isize)