### PR TITLE
Fixed crash on empty gradient stops vector.

### DIFF
--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -674,7 +674,7 @@ impl DrawTarget {
         unsafe {
             GradientStops::new(AzDrawTargetCreateGradientStops(
                     self.azure_draw_target,
-                    mem::transmute::<_,*const AzGradientStop>(&gradient_stops[0]),
+                    mem::transmute::<_,*const AzGradientStop>(gradient_stops.as_ptr()),
                     gradient_stops.len() as u32,
                     extend_mode.as_azure_extend_mode()))
         }


### PR DESCRIPTION
Somehow I missed this little bug when I uploaded the radial gradient patch, but here's the fix.