### PR TITLE
Fix line cap and line join.

### DIFF
--- a/src/azure-c.h
+++ b/src/azure-c.h
@@ -210,14 +210,14 @@ enum AzPatternType {
   AZ_PATTERN_RADIAL_GRADIENT
 };
 
-enum AzJoinStyle {
+enum AzJoinStyle: uint8_t {
   AZ_JOIN_BEVEL,
   AZ_JOIN_ROUND,
   AZ_JOIN_MITER,
   AZ_JOIN_MITER_OR_BEVEL
 };
 
-enum AzCapStyle {
+enum AzCapStyle: uint8_t {
   AZ_CAP_BUTT,
   AZ_CAP_ROUND,
   AZ_CAP_SQUARE
@@ -303,18 +303,14 @@ typedef struct _AzDrawOptions {
   */
 } AzDrawOptions;
 
-// FIXME: Again, bitfields
 typedef struct _AzStrokeOptions {
   AzFloat mLineWidth;
   AzFloat mMiterLimit;
   const AzFloat* mDashPattern;
   size_t mDashLength;
   AzFloat mDashOffset;
-  uint8_t fields;
-  /*
-    enum AzJoinStyle mLineJoin : 4;
-    enum AzCapStyle mLineCap : 3;
-   */
+  AzJoinStyle mLineJoin;
+  AzCapStyle mLineCap;
 } AzStrokeOptions;
 
 typedef struct _AzDrawSurfaceOptions {

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -173,18 +173,18 @@ pub static AZ_PATTERN_SURFACE: u32 = 1_u32;
 pub static AZ_PATTERN_LINEAR_GRADIENT: u32 = 2_u32;
 pub static AZ_PATTERN_RADIAL_GRADIENT: u32 = 3_u32;
 
-pub type enum_AzJoinStyle = c_uint;
-pub static AZ_JOIN_BEVEL: u32 = 0_u32;
-pub static AZ_JOIN_ROUND: u32 = 1_u32;
-pub static AZ_JOIN_MITER: u32 = 2_u32;
-pub static AZ_JOIN_MITER_OR_BEVEL: u32 = 3_u32;
+pub type enum_AzJoinStyle = c_uchar;
+pub static AZ_JOIN_BEVEL: u8 = 0_u8;
+pub static AZ_JOIN_ROUND: u8 = 1_u8;
+pub static AZ_JOIN_MITER: u8 = 2_u8;
+pub static AZ_JOIN_MITER_OR_BEVEL: u8 = 3_u8;
 
 pub type AzJoinStyle = enum_AzJoinStyle;
 
-pub type enum_AzCapStyle = c_uint;
-pub static AZ_CAP_BUTT: u32 = 0_u32;
-pub static AZ_CAP_ROUND: u32 = 1_u32;
-pub static AZ_CAP_SQUARE: u32 = 2_u32;
+pub type enum_AzCapStyle = c_uchar;
+pub static AZ_CAP_BUTT: u8 = 0_u8;
+pub static AZ_CAP_ROUND: u8 = 1_u8;
+pub static AZ_CAP_SQUARE: u8 = 2_u8;
 
 pub type AzCapStyle = enum_AzCapStyle;
 
@@ -363,7 +363,8 @@ pub struct struct__AzStrokeOptions {
     pub mDashPattern: *const AzFloat,
     pub mDashLength: size_t,
     pub mDashOffset: AzFloat,
-    pub fields: uint8_t,
+    pub mLineJoin: AzJoinStyle,
+    pub mLineCap: AzCapStyle,
 }
 
 pub type AzStrokeOptions = struct__AzStrokeOptions;

--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -165,8 +165,8 @@ pub enum CompositionOp {
     Count,
 }
 
-#[repr(i32)]
-#[derive(Clone, PartialEq)]
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum JoinStyle {
     Bevel = 0,
     Round = 1,
@@ -180,8 +180,8 @@ impl JoinStyle {
     }
 }
 
-#[repr(i32)]
-#[derive(Clone, PartialEq)]
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum CapStyle {
     Butt = 0,
     Round = 1,
@@ -199,7 +199,8 @@ pub struct StrokeOptions<'a> {
     pub line_width: AzFloat,
     pub miter_limit: AzFloat,
     pub mDashPattern: &'a[AzFloat],
-    pub fields: uint8_t
+    pub line_join: JoinStyle,
+    pub line_cap: CapStyle,
 }
 
 impl<'a> StrokeOptions<'a> {
@@ -209,7 +210,8 @@ impl<'a> StrokeOptions<'a> {
             line_width: line_width,
             miter_limit: miter_limit,
             mDashPattern: dash_pattern,
-            fields: ((line_cap.as_azure_cap_style()) as u8) << 4 | ((line_join.as_azure_join_style()) as u8),
+            line_join: line_join,
+            line_cap: line_cap,
         }
     }
 
@@ -220,7 +222,8 @@ impl<'a> StrokeOptions<'a> {
             mDashPattern: self.mDashPattern.as_ptr(),
             mDashLength: self.mDashPattern.len() as size_t,
             mDashOffset: 0.0 as AzFloat,
-            fields: self.fields
+            mLineJoin: self.line_join.as_azure_join_style(),
+            mLineCap: self.line_cap.as_azure_cap_style(),
         }
     }
 }


### PR DESCRIPTION
This patch fixes the handling of line cap and line join. According to 2D.h, both of these are 1-byte values, and not bitfields.

This is the azure-side patch of servo/servo#5635.