### PR TITLE
Use stlport rather than stdc++ on Android

### DIFF
--- a/src/linkhack.rs
+++ b/src/linkhack.rs
@@ -19,7 +19,7 @@ extern { }
 
 #[cfg(target_os = "android")]
 #[link(name = "azure", kind = "static")]
-#[link(name = "stdc++")]
+#[link(name = "stlport")]
 #[link(name = "skia", kind = "static")]
 #[link(name = "expat")]
 #[link(name = "fontconfig")]


### PR DESCRIPTION
stlport is the right library to use and allows us to link properly on Gonk.