### PR TITLE
Implement fill_rect for surface pattern with repetition style.

### DIFF
--- a/src/azure-c.cpp
+++ b/src/azure-c.cpp
@@ -724,7 +724,7 @@ extern "C" AzSurfacePatternRef
 AzCreateSurfacePattern(AzSourceSurfaceRef aSurface) {
     gfx::SourceSurface *gfxSourceSurface = reinterpret_cast<gfx::SourceSurface*>(aSurface);
     gfx::SurfacePattern* gfxSurfacePattern = new
-        gfx::SurfacePattern(gfxSourceSurface, gfx::ExtendMode::CLAMP);
+        gfx::SurfacePattern(gfxSourceSurface, gfx::ExtendMode::REPEAT);
     return gfxSurfacePattern;
 }
 
@@ -736,6 +736,12 @@ AzCloneSurfacePattern(AzSurfacePatternRef aPattern) {
                                    gfxSurfacePattern->mMatrix,
                                    gfxSurfacePattern->mFilter,
                                    gfxSurfacePattern->mSamplingRect);
+}
+
+extern "C" AzIntSize
+AzSurfacePatternGetSize(AzSurfacePatternRef aPattern) {
+    gfx::SurfacePattern *gfxSurfacePattern = static_cast<gfx::SurfacePattern*>(aPattern);
+    return AzSourceSurfaceGetSize(gfxSurfacePattern->mSurface);
 }
 
 extern "C" void

--- a/src/azure-c.h
+++ b/src/azure-c.h
@@ -466,6 +466,8 @@ AzSurfacePatternRef AzCreateSurfacePattern(AzSourceSurfaceRef aSurface);
 
 AzSurfacePatternRef AzCloneSurfacePattern(AzSurfacePatternRef aPattern);
 
+AzIntSize AzSurfacePatternGetSize(AzSurfacePatternRef aPattern);
+
 void AzReleasePattern(AzPatternRef aPattern);
 
 void AzReleaseGradientStops(AzGradientStopsRef aStops);

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -559,6 +559,8 @@ pub fn AzCreateSurfacePattern(aSurface: AzSourceSurfaceRef)
 pub fn AzCloneSurfacePattern(aPattern: AzSurfacePatternRef)
                              -> AzSurfacePatternRef;
 
+pub fn AzSurfacePatternGetSize(aPattern: AzSurfacePatternRef) -> AzIntSize;
+
 pub fn AzReleaseSourceSurface(aSurface: AzSourceSurfaceRef);
 
 pub fn AzSourceSurfaceGetSize(aSurface: AzSourceSurfaceRef) -> AzIntSize;

--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -44,7 +44,7 @@ use azure::{AzDrawTargetStroke, AzPathBuilderArc, AzPathBuilderFinish, AzRelease
 use azure::{AzDrawTargetFill, AzPathRef, AzReleasePath, AzDrawTargetPushClip, AzDrawTargetPopClip};
 use azure::{AzLinearGradientPatternRef, AzRadialGradientPatternRef, AzSurfacePatternRef, AzMatrix, AzPatternRef};
 use azure::{AzCreateLinearGradientPattern, AzCreateRadialGradientPattern, AzCreateSurfacePattern, AzDrawTargetPushClipRect};
-use azure::{AzCloneLinearGradientPattern, AzCloneRadialGradientPattern, AzCloneSurfacePattern};
+use azure::{AzCloneLinearGradientPattern, AzCloneRadialGradientPattern, AzCloneSurfacePattern, AzSurfacePatternGetSize};
 use azure::{AzDrawTargetDrawSurfaceWithShadow, AzDrawTargetCreateShadowDrawTarget};
 use azure::{AzDrawTargetCreateSimilarDrawTarget, AzDrawTargetGetTransform};
 use azure::{AzFilterNodeSetSourceSurfaceInput, AzReleaseFilterNode, AzDrawTargetCreateFilter};
@@ -569,6 +569,7 @@ impl DrawTarget {
             None => ptr::null_mut(),
             Some(ref mut draw_options) => draw_options as *mut AzDrawOptions
         };
+
         unsafe {
             AzDrawTargetFillRect(self.azure_draw_target,
                                  &mut rect.as_azure_rect(),
@@ -1186,6 +1187,8 @@ impl RadialGradientPattern {
 
 pub struct SurfacePattern {
     pub azure_surface_pattern: AzSurfacePatternRef,
+    pub repeat_x: bool,
+    pub repeat_y: bool,
 }
 
 impl Drop for SurfacePattern {
@@ -1202,19 +1205,29 @@ impl Clone for SurfacePattern {
             SurfacePattern {
                 azure_surface_pattern:
                     AzCloneSurfacePattern(self.azure_surface_pattern),
+                    repeat_x: self.repeat_x,
+                    repeat_y: self.repeat_y,
             }
         }
     }
 }
 
 impl SurfacePattern {
-    pub fn new(surface: AzSourceSurfaceRef)
+    pub fn new(surface: AzSourceSurfaceRef, repeat_x: bool, repeat_y: bool)
                -> SurfacePattern {
         unsafe {
             SurfacePattern {
                 azure_surface_pattern:
                     AzCreateSurfacePattern(surface),
+                    repeat_x: repeat_x,
+                    repeat_y: repeat_y,
             }
+        }
+    }
+
+    pub fn size(&self) -> AzIntSize {
+        unsafe {
+            AzSurfacePatternGetSize(self.azure_surface_pattern)
         }
     }
 }


### PR DESCRIPTION
SurfacePattern has ExtendMode::REPEAT.
Clipping is used to handle 'repeat-x', 'repeat-y' and 'no-repeat'.