### PR TITLE
Patches for fill and stroke on canvas in servo.

### DIFF
--- a/src/azure-c.cpp
+++ b/src/azure-c.cpp
@@ -721,10 +721,11 @@ AzCloneRadialGradientPattern(AzRadialGradientPatternRef aPattern) {
 }
 
 extern "C" AzSurfacePatternRef
-AzCreateSurfacePattern(AzSourceSurfaceRef aSurface) {
+AzCreateSurfacePattern(AzSourceSurfaceRef aSurface, AzExtendMode aExtendMode) {
     gfx::SourceSurface *gfxSourceSurface = reinterpret_cast<gfx::SourceSurface*>(aSurface);
+    gfx::ExtendMode gfxExtendMode = static_cast<gfx::ExtendMode>(aExtendMode);
     gfx::SurfacePattern* gfxSurfacePattern = new
-        gfx::SurfacePattern(gfxSourceSurface, gfx::ExtendMode::REPEAT);
+        gfx::SurfacePattern(gfxSourceSurface, gfxExtendMode);
     return gfxSurfacePattern;
 }
 

--- a/src/azure-c.h
+++ b/src/azure-c.h
@@ -462,7 +462,7 @@ AzRadialGradientPatternRef AzCreateRadialGradientPattern(const AzPoint *aCenter1
 
 AzRadialGradientPatternRef AzCloneRadialGradientPattern(AzRadialGradientPatternRef aPattern);
 
-AzSurfacePatternRef AzCreateSurfacePattern(AzSourceSurfaceRef aSurface);
+AzSurfacePatternRef AzCreateSurfacePattern(AzSourceSurfaceRef aSurface, AzExtendMode aExtendMode);
 
 AzSurfacePatternRef AzCloneSurfacePattern(AzSurfacePatternRef aPattern);
 

--- a/src/azure.rs
+++ b/src/azure.rs
@@ -553,7 +553,7 @@ pub fn AzCreateRadialGradientPattern(aCenter1: *const AzPoint,
 pub fn AzCloneRadialGradientPattern(aPattern: AzRadialGradientPatternRef)
                                     -> AzRadialGradientPatternRef;
 
-pub fn AzCreateSurfacePattern(aSurface: AzSourceSurfaceRef)
+pub fn AzCreateSurfacePattern(aSurface: AzSourceSurfaceRef, aExtendMode: AzExtendMode)
                               -> AzSurfacePatternRef;
 
 pub fn AzCloneSurfacePattern(aPattern: AzSurfacePatternRef)


### PR DESCRIPTION
- Modify fill and stroke functions to handle all pattern types.
- Add the code to check the zero size gradient.
- Set ExtendMode::Clamp for SurfacePattern in case of no-repeat.

r? @pcwalton @nox @jdm 
cc @yichoi 