### PR TITLE
Do not use system include path for freetype

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -39,7 +39,6 @@ CXXFLAGS += \
 	-std=gnu++11 \
 	-fPIC \
 	-Ilibazure \
-	-I/usr/include/freetype2 \
 	-DMOZ_GFX \
 	-DMOZ_WARN_UNUSED_RESULT="" \
 	$(NULL)


### PR DESCRIPTION
This reverts commit 1e7317e66a3f4e9b256d6e9190038b222fc8e603.

This commit has caused some issues with Android builds. This revert
rolls it out for the moment so that we can fix it later and have Android
building now.