### PR TITLE
We do not need to link against skia because it is statically pulled in

### DIFF
--- a/src/azure-c.cpp
+++ b/src/azure-c.cpp
@@ -201,7 +201,7 @@ AzCreateDrawTargetForData(AzBackendType aBackend, unsigned char *aData, AzIntSiz
 
 extern "C" AzDrawTargetRef
 AzCreateDrawTargetSkiaWithGrContextAndFBO(SkiaGrContextRef aGrContext, unsigned int aFBOID, AzIntSize *aSize, AzSurfaceFormat aFormat) {
-    GrContext *grContext = reinterpret_cast<GrContext*>(aGrContext);
+    GrContext *grContext = static_cast<GrContext*>(aGrContext);
     gfx::IntSize *size = reinterpret_cast<gfx::IntSize*>(aSize);
     gfx::SurfaceFormat surfaceFormat = static_cast<gfx::SurfaceFormat>(aFormat);
     RefPtr<gfx::DrawTarget> target = gfx::Factory::CreateDrawTargetSkiaWithGrContextAndFBO(grContext,

--- a/src/linkhack.rs
+++ b/src/linkhack.rs
@@ -7,8 +7,6 @@
 #[cfg(target_os = "linux")]
 #[link(name = "azure", kind = "static")]
 #[link(name = "stdc++")]
-#[link(name = "skia", kind = "static")]
-// skia must come before freetype for linking to succeed
 #[link(name = "freetype")]
 #[link(name = "bz2")]
 // fontconfig must come before expat for linking to succeed
@@ -20,7 +18,6 @@ extern { }
 #[cfg(target_os = "android")]
 #[link(name = "azure", kind = "static")]
 #[link(name = "stdc++")]
-#[link(name = "skia", kind = "static")]
 #[link(name = "expat")]
 #[link(name = "fontconfig")]
 #[link(name = "EGL")]
@@ -29,7 +26,6 @@ extern { }
 #[cfg(target_os = "macos")]
 #[link(name = "azure", kind = "static")]
 #[link(name = "stdc++")]
-#[link(name = "skia", kind = "static")]
 #[link(name = "objc")]
 #[link(name = "IOSurface", kind = "framework")]
 #[link(name = "OpenGL", kind = "framework")]

--- a/src/scaled_font.rs
+++ b/src/scaled_font.rs
@@ -140,7 +140,6 @@ impl ScaledFont {
 // FIXME: Move this stuff to a rust-skia?
 // FIXME: Demangle the names!!!
 #[cfg(target_os="macos")]
-#[link(name = "skia")]
 extern {
     pub fn _Z26SkCreateTypefaceFromCTFontPK8__CTFont(font: CTFontRef) -> *mut SkTypeface;
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,6 +6,7 @@
 // on Linux to link correctly.
 
 #[cfg(target_os = "linux")]
+#[link(name = "skia")]
 #[link(name = "GL")]
 extern { }
 


### PR DESCRIPTION
r? @metajack 

I've tested this PR against OSX, OSX/cef, and Linux (OSX/cef is where we were seeing the issue in the rustup). The code being removed was causing us to pull in the static library twice and then rely on the linker to remove / deal with the second copy.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/181)
<!-- Reviewable:end -->
