### PR TITLE
Update to support the latest skia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
-rust:
-  - nightly
+# We pin rust here, because aster (0.3.3) is broken with the latest
+# rust nightly. Once aster is fixed we can change this back to 'nightly.'
+rust: nightly-2015-07-10
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -453,11 +453,11 @@ impl DrawTarget {
     }
 
     pub fn new_with_gl_rasterization_context(gl_rasterization_context: Arc<GLRasterizationContext>,
-                                              format: SurfaceFormat)
-                                              -> DrawTarget {
+                                             format: SurfaceFormat)
+                                             -> DrawTarget {
         let mut size = gl_rasterization_context.size.as_azure_int_size();
         let azure_draw_target = unsafe {
-            AzCreateDrawTargetSkiaWithGrContextAndFBO(gl_rasterization_context.gr_context,
+            AzCreateDrawTargetSkiaWithGrContextAndFBO(gl_rasterization_context.gl_context.gr_context,
                                                       gl_rasterization_context.framebuffer_id,
                                                       &mut size,
                                                       format.as_azure_surface_format())


### PR DESCRIPTION
GLContext has been split out from GLRasterizationContext.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/187)
<!-- Reviewable:end -->
