### PR TITLE
Pin travis to the 2015-07-10 rust nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
-rust:
-  - nightly
+# We pin rust here, because aster (0.3.3) is broken with the latest
+# rust nightly. Once aster is fixed we can change this back to 'nightly.'
+rust: nightly-2015-07-10
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
This is a temporary work-around for an incompatibility between the
latest version of aster and the current rust nightly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/188)
<!-- Reviewable:end -->
