### PR TITLE
This will fix a panic in Canvas

### DIFF
--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -701,7 +701,7 @@ impl DrawTarget {
                                            stride: i32,
                                            format: SurfaceFormat)
                                            -> SourceSurface {
-        assert_eq!(data.len() as i32, stride * size.height);
+        assert!(data.len() as i32 >= stride * size.height);
         unsafe {
             let azure_surface = AzDrawTargetCreateSourceSurfaceFromData(
                 self.azure_draw_target,


### PR DESCRIPTION
When a script defines a bigger area for a Canvas element than it was defined by CSS style, Servo will panic and exit execution.

This patch fix this bug.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/195)
<!-- Reviewable:end -->
