### PR TITLE
win32: add some libs a few extra times to get around lib ordering issues

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,4 +13,13 @@ fn main() {
         .unwrap()
         .success());
     println!("cargo:rustc-flags=-L native={}", env::var("OUT_DIR").unwrap());
+
+    let target = env::var("TARGET").unwrap();
+    // We need a lot of stuff on Windows and we need to resolve static
+    // link order.. so just list things a few extra times.
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=skia");
+        println!("cargo:rustc-link-lib=freetype");
+        println!("cargo:rustc-link-lib=fontconfig");
+    }
 }


### PR DESCRIPTION
This is a hack.  It's not a very good hack, but it does work.. basically we need to add some libs a few times to get the left-to-right symbol resolution to work properly in the final link.  We can fix this by either dynamic linking everything, or by using -( -) (--start-group ... --end-group), which causes gnu LD to repeatedly search everything within the group until no additional symbols are resolved.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/200)
<!-- Reviewable:end -->
