### PR TITLE
Only set target-specific CC and AR for cross-compile

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -1,4 +1,4 @@
-ifeq (eabi,$(findstring eabi,$(TARGET)))
+ifneq ($(HOST),$(TARGET))
 CXX ?= $(TARGET)-g++
 AR ?= $(TARGET)-ar
 else


### PR DESCRIPTION
Checking for "eabi" in $TARGET causes failure to build natively on ARM systems.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/202)
<!-- Reviewable:end -->
