### PR TITLE
Use pkg-config to find freetype include dir

### DIFF
--- a/makefile.cargo
+++ b/makefile.cargo
@@ -64,7 +64,6 @@ CXXFLAGS += \
 endif
 
 CXXFLAGS += \
-	-I "$(DEP_FREETYPE_OUTDIR)/include" \
 	-iquote "$(DEP_SKIA_OUTDIR)/include" \
 	-iquote "$(DEP_SKIA_OUTDIR)/include/core" \
 	-iquote "$(DEP_SKIA_OUTDIR)/include/config" \
@@ -75,6 +74,12 @@ CXXFLAGS += \
 	-iquote "$(DEP_SKIA_OUTDIR)/include/gpu/gl" \
 	-DUSE_SKIA \
 	-DUSE_SKIA_GPU
+
+ifdef DEP_FREETYPE_OUTDIR
+	CXXFLAGS += "-I$(DEP_FREETYPE_OUTDIR)/include"
+else
+	CXXFLAGS += `pkg-config --cflags freetype2`
+endif
 
 USE_CLANG = $(shell $(CXX) --version|grep -c 'clang')
 


### PR DESCRIPTION
The DEP_FREETYPE_OUTDIR variable is not available when using freetype2 via pkg-config.  (See servo/libfreetype2#17.)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/203)
<!-- Reviewable:end -->
