### PR TITLE
Stop doing linkhack linking, at least on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,17 @@ use std::env;
 
 
 fn main() {
+    let target = env::var("TARGET").unwrap();
     assert!(Command::new("make")
         .args(&["-R", "-f", "makefile.cargo", &format!("-j{}", env::var("NUM_JOBS").unwrap())])
         .status()
         .unwrap()
         .success());
     println!("cargo:rustc-flags=-L native={}", env::var("OUT_DIR").unwrap());
+
+    if target.contains("windows") {
+        println!("cargo:rustc-link-lib=static=azure");
+        println!("cargo:rustc-link-lib=stdc++");
+        println!("cargo:rustc-link-lib=uuid");
+    }
 }

--- a/src/linkhack.rs
+++ b/src/linkhack.rs
@@ -34,13 +34,3 @@ extern { }
 #[link(name = "ApplicationServices", kind = "framework")]
 extern { }
 
-#[cfg(target_os = "windows")]
-#[link(name = "azure")] // if I do kind = "static", nothing is output in the final gcc link on windows
-#[link(name = "stdc++")]
-#[link(name = "freetype")]
-#[link(name = "bz2")]
-// fontconfig must come before expat for linking to succeed
-#[link(name = "fontconfig")]
-#[link(name = "expat")]
-#[link(name = "uuid")]
-extern { }


### PR DESCRIPTION
Using cargo linking directives fixes a bunch of link issues on Windows here, including being able to do a static link of the azure lib.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/205)
<!-- Reviewable:end -->
