### PR TITLE
Bumping version to 0.4.5 to force other packages to pick up new skia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/azure/"
 


### PR DESCRIPTION
@mbrubeck I think this is what prevents us to move to the updated skia in servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/226)
<!-- Reviewable:end -->
