### PR TITLE
Correctly ask support for C++11 to CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 
 rust:
   - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
-rust: nightly
+
+rust:
+  - stable
+  - beta
+  - nightly
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ rust:
   - beta
   - nightly
 
+os:
+  - linux
+  - osx
+
 addons:
   apt:
     sources:
@@ -16,10 +20,13 @@ addons:
     - g++-4.7
 
 before_install:
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 20
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 20
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 20; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 20; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew outdated cmake || brew upgrade cmake; fi
   - g++ --version
-  - sudo apt-get update -qq
-  
+  - cmake --version
+
 notifications:
   webhooks: http://build.servo.org:54856/travis

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,18 +54,20 @@ include_directories(
 	$ENV{DEP_SKIA_OUTDIR}/src
 )
 
-if(NOT "$ENV{DEP_FREETYPE_OUTDIR}" STREQUAL "")
-  include_directories($ENV{DEP_FREETYPE_OUTDIR}/include)
-  # makefile.cargo never added any link flags or libs in this case,
-  # so we don't either
-else()
-  # We need to work with older cmake -- pkg_check_modules was added in
-  # a version of cmake newer than what Ubuntu 14.04 LTS ships with.
-  #pkg_check_modules(FREETYPE REQUIRED freetype2)
-  EXEC_PROGRAM(pkg-config ARGS --cflags freetype2 OUTPUT_VARIABLE FREETYPE_CFLAGS)
-  EXEC_PROGRAM(pkg-config ARGS --libs freetype2 OUTPUT_VARIABLE FREETYPE_CLDFLAGS)
-  add_definitions(${FREETYPE_CFLAGS})
-  link_libraries(${FREETYPE_CLDFLAGS})
+if(NOT APPLE)
+  if(NOT "$ENV{DEP_FREETYPE_OUTDIR}" STREQUAL "")
+    include_directories($ENV{DEP_FREETYPE_OUTDIR}/include)
+    # makefile.cargo never added any link flags or libs in this case,
+    # so we don't either
+  else()
+    # We need to work with older cmake -- pkg_check_modules was added in
+    # a version of cmake newer than what Ubuntu 14.04 LTS ships with.
+    #pkg_check_modules(FREETYPE REQUIRED freetype2)
+    EXEC_PROGRAM(pkg-config ARGS --cflags freetype2 OUTPUT_VARIABLE FREETYPE_CFLAGS)
+    EXEC_PROGRAM(pkg-config ARGS --libs freetype2 OUTPUT_VARIABLE FREETYPE_CLDFLAGS)
+    add_definitions(${FREETYPE_CFLAGS})
+    link_libraries(${FREETYPE_CLDFLAGS})
+  endif()
 endif()
 
 add_definitions(-DUSE_SKIA -DUSE_SKIA_GPU)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if(NOT WIN32)
   add_definitions(-fPIC)
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_definitions(-std=gnu++11)
 endif()
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure"
-version = "0.4.7"
+version = "0.5.0"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/azure/"
 
@@ -20,7 +20,7 @@ heapsize_plugin = {version = "0.1.0", optional = true}
 libc = "0.2"
 serde = {version = ">=0.6.1, <0.8", optional = true}
 serde_macros = {version = ">=0.6.1, <0.8", optional = true}
-servo-skia = "0.20130412.8"
+servo-skia = "0.20130412.12"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 freetype = { git = "https://github.com/servo/rust-freetype" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "azure"]
 #![crate_type = "rlib"]
-#![feature(custom_derive, plugin)]
+#![cfg_attr(feature = "plugins", feature(custom_derive, plugin))]
 #![cfg_attr(feature = "plugins", plugin(serde_macros))]
 #![cfg_attr(feature = "plugins", plugin(heapsize_plugin))]
 


### PR DESCRIPTION
We also bump to 0.5.0 as it should have been done when switching to CMake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/233)
<!-- Reviewable:end -->
