### PR TITLE
Update euclid, freetype-sys, skia.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,10 @@ if(NOT APPLE)
     # We need to work with older cmake -- pkg_check_modules was added in
     # a version of cmake newer than what Ubuntu 14.04 LTS ships with.
     #pkg_check_modules(FREETYPE REQUIRED freetype2)
-    EXEC_PROGRAM(pkg-config ARGS --cflags freetype2 OUTPUT_VARIABLE FREETYPE_CFLAGS)
+    EXEC_PROGRAM(pkg-config ARGS --cflags freetype2 OUTPUT_VARIABLE FREETYPE_CFLAGS RESULT_VARIABLE FREETYPE_NOT_FOUND)
+    if(FREETYPE_NOT_FOUND)
+      message(FATAL_ERROR "Freetype is required by rust-azure for this build, but it was not built by the freetype crate nor found by pkg-config")
+    endif()
     EXEC_PROGRAM(pkg-config ARGS --libs freetype2 OUTPUT_VARIABLE FREETYPE_CLDFLAGS)
     add_definitions(${FREETYPE_CFLAGS})
     link_libraries(${FREETYPE_CLDFLAGS})

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,17 @@ plugins = ["serde", "serde_macros", "heapsize", "heapsize_plugin", "euclid/plugi
 cmake = "0.1"
 
 [dependencies]
-euclid = ">=0.6.1, <0.8"
+euclid = ">=0.6.1, <0.9"
 heapsize = {version = ">=0.2, <0.4", optional = true}
 heapsize_plugin = {version = "0.1.0", optional = true}
 libc = "0.2"
 serde = {version = ">=0.6.1, <0.8", optional = true}
 serde_macros = {version = ">=0.6.1, <0.8", optional = true}
-servo-skia = "0.20130412.12"
+servo-skia = "0.20130412.14"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 freetype = { git = "https://github.com/servo/rust-freetype" }
-servo-freetype-sys = "2.4.11"
+servo-freetype-sys = "4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = { version = "2.0.0", features = ["xlib"] }

--- a/src/azure_hl.rs
+++ b/src/azure_hl.rs
@@ -974,7 +974,7 @@ pub trait SourceSurfaceMethods {
         let size = unsafe {
             AzSourceSurfaceGetSize_(self.get_azure_source_surface())
         };
-        Size2D { width: size.width, height: size.height }
+        Size2D::new(size.width, size.height)
     }
 
     fn format(&self) -> SurfaceFormat {


### PR DESCRIPTION
Also includes the freetype reporting from #234.

r? @larsbergstrom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/235)
<!-- Reviewable:end -->
