### PR TITLE
Build for Android on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = {version = "1.0", optional = true}
 serde_derive = {version = "1.0", optional = true}
 servo-skia = "0.30000006.0"
 
-[target.'cfg(all(target_os = "linux", target_os = "android"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 freetype = "0.3"
 servo-freetype-sys = "4.0.1"
 

--- a/libazure/Types.h
+++ b/libazure/Types.h
@@ -6,13 +6,14 @@
 #ifndef MOZILLA_GFX_TYPES_H_
 #define MOZILLA_GFX_TYPES_H_
 
+// Required so that INT32_MAX can be defined on certain gcc versions
+#define __STDC_LIMIT_MACROS
+
 #include "mozilla/NullPtr.h"
 #include "mozilla/TypedEnum.h"
 
 #include <stddef.h>
 
-// Required so that INT32_MAX can be defined on certain gcc versions
-#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 
 namespace mozilla {


### PR DESCRIPTION
2 errors encountered when cross compiling for Android on macOS.
- freetype not found:
  all(target_os = "linux", target_os = "android"), a falsy value, is used as condition to add freetype crate dep. Building on Linux doesn't fail because freetype is most likely installed there as the fallback.
- INT16_(MIN|MAX), referenced in libazure/SIMD.h, are not defined:
  Although libazure/Types.h does define __STDC_LIMIT_MACROS before including stdint.h, it's too late because that header is also included in libazure/mozilla/NullPtr.h a few lines above.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/270)
<!-- Reviewable:end -->
