### PR TITLE
Update skia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure"
-version = "0.21.2"
+version = "0.22.0"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/azure/"
 repository = "https://github.com/servo/rust-azure"
@@ -23,7 +23,7 @@ heapsize_derive = {version = "0.1.0", optional = true}
 libc = "0.2"
 serde = {version = "1.0", optional = true}
 serde_derive = {version = "1.0", optional = true}
-servo-skia = "0.30000006"
+servo-skia = "0.30000007"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 servo-freetype-sys = "4.0.1"


### PR DESCRIPTION
See https://github.com/servo/skia/pull/145 and servo/gleam#130. We also need this to avoid duplicated versions tidy check failures in order to land the new gleam version in Servo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/279)
<!-- Reviewable:end -->
