### PR TITLE
Upgrade core foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cmake = "0.1"
 euclid = "0.16"
 libc = "0.2"
 serde = {version = "1.0", features=["derive"], optional = true}
-servo-skia = "0.30000009"
+servo-skia = "0.30000010"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 servo-freetype-sys = "4.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/azure/"
 repository = "https://github.com/servo/rust-azure"


### PR DESCRIPTION
This is a PR in a series of PRs originating at https://github.com/servo/core-foundation-rs/pull/132

The plan is to make a breaking change to `core-foundation` and release it as `0.5.0`. Hopefully we can manage to bring Servo and its entire dependency tree up to date as rapidly as possible in combination with this, as to use only the new core-foundation in Servo and all its deps. :)

TODO before merge:
- [x] Merge `skia`.
- [x] Remove the last commit from this PR, so we depend on code from crates.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/282)
<!-- Reviewable:end -->
