### PR TITLE
Clean up surface methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure"
-version = "0.33.0"
+version = "0.34.0"
 authors = ["The Servo Project Developers"]
 documentation = "http://doc.servo.org/azure/"
 repository = "https://github.com/servo/rust-azure"


### PR DESCRIPTION
We move SourceSurfaceMethods items to inherent methods on the couple of surface
types and we make DataSourceSurface::with_data into DataSourceSurface::data,
which is unsafe and returns a slice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-azure/293)
<!-- Reviewable:end -->
